### PR TITLE
Fix corruption in EMF Data URI conversion by avoiding newline substitution

### DIFF
--- a/lib/vectory/datauri.rb
+++ b/lib/vectory/datauri.rb
@@ -12,7 +12,9 @@ module Vectory
 
     def self.from_vector(vector)
       mimetype = vector.class.mimetype
-      content = vector.content.gsub("\r\n", "\n")
+      # content = vector.content.gsub("\r\n", "\n")
+      content = vector.content
+      content = content.gsub("\r\n", "\n") if vector.mime == "image/svg+xml"
       data = Base64.strict_encode64(content)
 
       new("data:#{mimetype};base64,#{data}")


### PR DESCRIPTION
### Fix: Prevent EMF Corruption During Data URI Conversion

#### Problem

The method `Datauri.from_vector` was applying `.gsub("\r\n", "\n")` to the content of all vector files before base64 encoding. While this normalization is useful for textual formats like SVG, it corrupts binary formats such as EMF. The corruption results in:

- A slight but consistent reduction in byte size (e.g., 101804 → 101800 bytes)
- Invalid EMF output after round-tripping through base64 encoding and decoding
- Inability to open the resulting file in some applications

This behavior affects any workflow that uses `.to_uri` on EMF files and later attempts to decode them.

#### Solution

This patch ensures that newline normalization is applied only to text-based formats. Specifically, it is now conditional on the MIME type being `image/svg+xml`. All other formats, including binary ones like EMF, are left untouched to preserve data integrity.

#### Testing

The issue was reproduced using a custom test script that:

1. Converts an SVG file to EMF using `img.to_emf`
2. Encodes the EMF to a Data URI using `to_uri`
3. Decodes the Data URI back to binary
4. Compares the original and decoded EMF contents

I was not able to retrieve the exact `figure-01.svg` file referenced in the related issue, but I tested the fix using multiple valid SVG files, including minimal examples, and confirmed that the round-trip EMF outputs are now byte-for-byte identical.

#### Changes

- `lib/vectory/datauri.rb`: Conditional newline substitution based on MIME type
