### PR TITLE
chore: migrate from inkscape-rake to generic-rake workflow

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -14,8 +14,11 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/inkscape-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
     with:
-      private-fonts: 'false'
+      setup-tools: inkscape,ghostscript
+      submodules: true
+      choco-cache: true
+      private-fonts: false
     secrets:
       pat_token: ${{ secrets.CLARICLE_CI_PAT_TOKEN }}


### PR DESCRIPTION
Migrate to the consolidated generic-rake.yml workflow. Part of metanorma/ci#259.